### PR TITLE
Don't use std::ptrdiff type

### DIFF
--- a/include/openPMD/regions/NDPoint.hpp
+++ b/include/openPMD/regions/NDPoint.hpp
@@ -31,7 +31,7 @@ namespace detail {
 template <typename T> class VPoint {
 public:
   using value_type = T;
-  using size_type = std::ptrdiff_t;
+  using size_type = std::size_t;
 
   virtual std::unique_ptr<VPoint> copy() const = 0;
 

--- a/include/openPMD/regions/Point.hpp
+++ b/include/openPMD/regions/Point.hpp
@@ -39,7 +39,7 @@ public:
   using value_type = T;
   /** Return type of Point::size()
    */
-  using size_type = std::ptrdiff_t;
+  using size_type = std::size_t;
 
   /** Create a value-initialized Point
    *

--- a/test/BoxTest.cpp
+++ b/test/BoxTest.cpp
@@ -47,7 +47,7 @@ template <typename B> void test_Box(const B &box) {
   for (int iter = 0; iter < 100; ++iter) {
 
     B N(box);
-    CHECK(N.ndims() == std::ptrdiff_t(D));
+    CHECK(N.ndims() == D);
     CHECK(N.empty());
     for (std::size_t d = 0; d < D; ++d)
       CHECK(N.lower()[d] >= N.upper()[d]);

--- a/test/PointTest.cpp
+++ b/test/PointTest.cpp
@@ -56,10 +56,10 @@ template <typename P> void test_Point_bool(const P &p) {
   for (int iter = 0; iter < 100; ++iter) {
 
     P n = p;
-    CHECK(n.ndims() == std::ptrdiff_t(D));
+    CHECK(n.ndims() == D);
     for (std::size_t d = 0; d < D; ++d)
       CHECK(n[d] == 0);
-    CHECK(n.size() == std::ptrdiff_t(D));
+    CHECK(n.size() == D);
 
     const P x = randp();
     const P y = randp();
@@ -188,7 +188,7 @@ template <typename P> void test_Point_int(const P &p) {
   for (int iter = 0; iter < 100; ++iter) {
 
     P n(p);
-    CHECK(n.size() == std::ptrdiff_t(D));
+    CHECK(n.size() == D);
     for (std::size_t d = 0; d < D; ++d)
       CHECK(n[d] == 0);
 
@@ -214,7 +214,7 @@ template <typename P> void test_Point_int(const P &p) {
           sum(x + y));
 
     CHECK(sum(n) == 0);
-    CHECK(sum(n + 1) == std::ptrdiff_t(D));
+    CHECK(sum(n + 1) == T(D));
     CHECK(product(n) == (D == 0 ? 1 : 0));
     CHECK(product(n + 1) == 1);
     CHECK(min_element(n) == (D == 0 ? std::numeric_limits<T>::max() : 0));
@@ -349,7 +349,7 @@ template <typename P> void test_Point_float(const P &p) {
   for (int iter = 0; iter < 100; ++iter) {
 
     P n(p);
-    CHECK(n.size() == std::ptrdiff_t(D));
+    CHECK(n.size() == D);
     for (std::size_t d = 0; d < D; ++d)
       CHECK(n[d] == 0);
 
@@ -376,16 +376,16 @@ template <typename P> void test_Point_float(const P &p) {
       for (std::size_t d = 0; d < D; ++d) {
         const auto a1 = x[d];
         const auto x1 = x.erase(d);
-        CHECK(x1.ndims() == std::ptrdiff_t(D) - 1);
+        CHECK(x1.ndims() == D - 1);
         const auto x2 = x1.insert(d, a1);
-        CHECK(x2.ndims() == std::ptrdiff_t(D));
+        CHECK(x2.ndims() == D);
         CHECK(eq_helper(x2, x));
       }
     }
     // insert-remove is no-op
     for (std::size_t d = 0; d <= D; ++d) {
       const auto x1 = x.insert(d, a);
-      CHECK(x1.ndims() == std::ptrdiff_t(D) + 1);
+      CHECK(x1.ndims() == D + 1);
       CHECK(x1[d] == a);
       CHECK(eq(x1.erase(d), x));
     }


### PR DESCRIPTION
This fixes `-Wsign-compare` warnings when building with clang version 11.0.1 (self-compiled inside an Ubuntu 20.04 Singularity container on an x64 system)