### PR TITLE
Review for Julia bindings PR

### DIFF
--- a/src/binding/julia/Attributable.cpp
+++ b/src/binding/julia/Attributable.cpp
@@ -2,15 +2,26 @@
 
 #include "defs.hpp"
 
+namespace
+{
+struct UseType
+{
+    template <typename T>
+    static void call(jlcxx::TypeWrapper<Attributable> type)
+    {
+        type.method(
+            "cxx_set_attribute_" + datatypeToString(determineDatatype<T>()) +
+                "!",
+            &Attributable::setAttribute<T>);
+    }
+};
+} // namespace
+
 void define_julia_Attributable(jlcxx::Module &mod)
 {
     auto type = mod.add_type<Attributable>("CXX_Attributable");
 
-#define USE_TYPE(NAME, ENUM, TYPE)                                             \
-    type.method(                                                               \
-        "cxx_set_attribute_" NAME "!", &Attributable::setAttribute<TYPE>);
-    {FORALL_OPENPMD_TYPES(USE_TYPE)}
-#undef USE_TYPE
+    forallJuliaTypes<UseType>(type);
 
     type.method("cxx_get_attribute", &Attributable::getAttribute);
     type.method("cxx_delete_attribute!", &Attributable::deleteAttribute);

--- a/src/binding/julia/Attribute.cpp
+++ b/src/binding/julia/Attribute.cpp
@@ -2,16 +2,25 @@
 
 #include "defs.hpp"
 
+namespace
+{
+struct UseType
+{
+    template <typename T>
+    static void call(jlcxx::TypeWrapper<Attribute> type)
+    {
+        type.method(
+            "cxx_get_" + datatypeToString(determineDatatype<T>()),
+            &Attribute::get<T>);
+    }
+};
+} // namespace
+
 void define_julia_Attribute(jlcxx::Module &mod)
 {
     auto type = mod.add_type<Attribute>("CXX_Attribute");
 
     type.method("cxx_dtype", [](const Attribute &attr) { return attr.dtype; });
 
-#define USE_TYPE(NAME, ENUM, TYPE)                                             \
-    type.method("cxx_get_" NAME, &Attribute::get<TYPE>);
-    {
-        FORALL_OPENPMD_TYPES(USE_TYPE)
-    }
-#undef USE_TYPE
+    forallJuliaTypes<UseType>(type);
 }

--- a/src/binding/julia/BaseRecordComponent.cpp
+++ b/src/binding/julia/BaseRecordComponent.cpp
@@ -8,7 +8,7 @@ namespace jlcxx
 template <>
 struct SuperType<BaseRecordComponent>
 {
-    typedef Attributable type;
+    using type = Attributable;
 };
 } // namespace jlcxx
 

--- a/src/binding/julia/ChunkInfo.cpp
+++ b/src/binding/julia/ChunkInfo.cpp
@@ -8,7 +8,7 @@ namespace jlcxx
 template <>
 struct SuperType<WrittenChunkInfo>
 {
-    typedef ChunkInfo type;
+    using type = ChunkInfo;
 };
 } // namespace jlcxx
 

--- a/src/binding/julia/Container.hpp
+++ b/src/binding/julia/Container.hpp
@@ -14,14 +14,13 @@ namespace jlcxx
 template <typename T, typename K>
 struct SuperType<Container<T, K>>
 {
-    typedef Attributable type;
+    using type = Attributable;
 };
 } // namespace jlcxx
 
+using julia_Container_type_t =
+    jlcxx::TypeWrapper<jlcxx::Parametric<jlcxx::TypeVar<1>, jlcxx::TypeVar<2>>>;
 // TODO: use std::optional instead of std::unique_ptr
-typedef jlcxx::TypeWrapper<
-    jlcxx::Parametric<jlcxx::TypeVar<1>, jlcxx::TypeVar<2>>>
-    julia_Container_type_t;
 extern std::unique_ptr<julia_Container_type_t> julia_Container_type;
 
 template <typename Eltype, typename Keytype>

--- a/src/binding/julia/Container.hpp
+++ b/src/binding/julia/Container.hpp
@@ -36,7 +36,6 @@ void define_julia_Container(jlcxx::Module &mod)
         using ContainerT = typename decltype(type)::type;
         using key_type = typename ContainerT::key_type;
         using mapped_type = typename ContainerT::mapped_type;
-        using size_type = typename ContainerT::size_type;
         static_assert(std::is_same_v<Eltype, mapped_type>);
         static_assert(std::is_same_v<Keytype, key_type>);
 
@@ -62,9 +61,7 @@ void define_julia_Container(jlcxx::Module &mod)
         type.method("cxx_count", &ContainerT::count);
         type.method("cxx_contains", &ContainerT::contains);
         type.method(
-            "cxx_delete!",
-            static_cast<size_type (ContainerT::*)(const key_type &)>(
-                &ContainerT::erase));
+            "cxx_delete!", overload_cast<const key_type &>(&ContainerT::erase));
         type.method("cxx_keys", [](const ContainerT &cont) {
             std::vector<key_type> res;
             res.reserve(cont.size());

--- a/src/binding/julia/Datatype.cpp
+++ b/src/binding/julia/Datatype.cpp
@@ -2,14 +2,26 @@
 
 #include "defs.hpp"
 
+namespace
+{
+struct UseType
+{
+    template <typename T>
+    static void call(jlcxx::Module &mod)
+    {
+        Datatype const dt = determineDatatype<T>();
+        mod.set_const(datatypeToString(dt), dt);
+    }
+};
+} // namespace
+
 void define_julia_Datatype(jlcxx::Module &mod)
 {
     mod.add_bits<Datatype>("Datatype", jlcxx::julia_type("CppEnum"));
     jlcxx::stl::apply_stl<Datatype>(mod);
 
-#define USE_TYPE(NAME, ENUM, TYPE) mod.set_const(NAME, ENUM);
-    {FORALL_OPENPMD_TYPES(USE_TYPE)}
-#undef USE_TYPE
+    forallJuliaTypes<UseType>(mod);
+
     mod.set_const("UNDEFINED", Datatype::UNDEFINED);
 
     mod.set_const("openPMD_datatypes", openPMD_Datatypes);

--- a/src/binding/julia/Iteration.cpp
+++ b/src/binding/julia/Iteration.cpp
@@ -10,7 +10,7 @@ namespace jlcxx
 template <>
 struct SuperType<Iteration>
 {
-    typedef Attributable type;
+    using type = Attributable;
 };
 } // namespace jlcxx
 

--- a/src/binding/julia/Iteration.cpp
+++ b/src/binding/julia/Iteration.cpp
@@ -25,9 +25,7 @@ void define_julia_Iteration(jlcxx::Module &mod)
     type.method("cxx_set_dt!", &Iteration::setDt<double>);
     type.method("cxx_time_unit_SI", &Iteration::timeUnitSI);
     type.method("cxx_set_time_unit_SI!", &Iteration::setTimeUnitSI);
-    type.method(
-        "cxx_close",
-        static_cast<Iteration &(Iteration::*)(bool)>(&Iteration::close));
+    type.method("cxx_close", overload_cast<bool>(&Iteration::close));
     type.method("cxx_open", &Iteration::open);
     type.method("cxx_closed", &Iteration::closed);
     type.method("cxx_meshes", [](Iteration &iter) -> Container<Mesh> & {

--- a/src/binding/julia/Mesh.cpp
+++ b/src/binding/julia/Mesh.cpp
@@ -8,7 +8,7 @@ namespace jlcxx
 template <>
 struct SuperType<Mesh>
 {
-    typedef Container<MeshRecordComponent> type;
+    using type = Container<MeshRecordComponent>;
 };
 } // namespace jlcxx
 

--- a/src/binding/julia/Mesh.cpp
+++ b/src/binding/julia/Mesh.cpp
@@ -46,8 +46,7 @@ void define_julia_Mesh(jlcxx::Module &mod)
 
     type.method("cxx_geometry", &Mesh::geometry);
     type.method(
-        "cxx_set_geometry!",
-        static_cast<Mesh &(Mesh::*)(Mesh::Geometry g)>(&Mesh::setGeometry));
+        "cxx_set_geometry!", overload_cast<Mesh::Geometry>(&Mesh::setGeometry));
     type.method("cxx_geometry_parameters", &Mesh::geometryParameters);
     type.method("cxx_set_geometry_parameters!", &Mesh::setGeometryParameters);
     type.method("cxx_data_order", &Mesh::dataOrder);

--- a/src/binding/julia/MeshRecordComponent.cpp
+++ b/src/binding/julia/MeshRecordComponent.cpp
@@ -8,7 +8,7 @@ namespace jlcxx
 template <>
 struct SuperType<MeshRecordComponent>
 {
-    typedef RecordComponent type;
+    using type = RecordComponent;
 };
 } // namespace jlcxx
 

--- a/src/binding/julia/MeshRecordComponent.cpp
+++ b/src/binding/julia/MeshRecordComponent.cpp
@@ -12,6 +12,20 @@ struct SuperType<MeshRecordComponent>
 };
 } // namespace jlcxx
 
+namespace
+{
+struct UseType
+{
+    template <typename T>
+    static void call(jlcxx::TypeWrapper<MeshRecordComponent> type)
+    {
+        type.method(
+            "cxx_make_constant_" + datatypeToString(determineDatatype<T>()),
+            &MeshRecordComponent::makeConstant<T>);
+    }
+};
+} // namespace
+
 void define_julia_MeshRecordComponent(jlcxx::Module &mod)
 {
     auto type = mod.add_type<MeshRecordComponent>(
@@ -19,11 +33,5 @@ void define_julia_MeshRecordComponent(jlcxx::Module &mod)
 
     type.method("cxx_position", &MeshRecordComponent::position<double>);
     type.method("cxx_set_position!", &MeshRecordComponent::setPosition<double>);
-#define USE_TYPE(NAME, ENUM, TYPE)                                             \
-    type.method(                                                               \
-        "cxx_make_constant_" NAME, &MeshRecordComponent::makeConstant<TYPE>);
-    {
-        FORALL_OPENPMD_TYPES(USE_TYPE)
-    }
-#undef USE_TYPE
+    forallJuliaTypes<UseType>(type);
 }

--- a/src/binding/julia/RecordComponent.cpp
+++ b/src/binding/julia/RecordComponent.cpp
@@ -13,7 +13,7 @@ namespace jlcxx
 template <>
 struct SuperType<RecordComponent>
 {
-    typedef BaseRecordComponent type;
+    using type = BaseRecordComponent;
 };
 } // namespace jlcxx
 

--- a/src/binding/julia/RecordComponent_load_chunk.cpp
+++ b/src/binding/julia/RecordComponent_load_chunk.cpp
@@ -2,17 +2,24 @@
 
 #include "defs.hpp"
 
+namespace
+{
+struct UseType
+{
+    template <typename T>
+    static void call(jlcxx::TypeWrapper<RecordComponent> &type)
+    {
+        type.method(
+            "cxx_load_" + datatypeToString(determineDatatype<T>()),
+            static_cast<void (RecordComponent::*)(
+                std::shared_ptr<T>, Offset, Extent)>(
+                &RecordComponent::loadChunk<T>));
+    }
+};
+} // namespace
+
 void define_julia_RecordComponent_load_chunk(
     jlcxx::Module & /*mod*/, jlcxx::TypeWrapper<RecordComponent> &type)
 {
-#define USE_TYPE(NAME, ENUM, TYPE)                                             \
-    type.method(                                                               \
-        "cxx_load_chunk_" NAME,                                                \
-        static_cast<void (RecordComponent::*)(                                 \
-            std::shared_ptr<TYPE>, Offset, Extent)>(                           \
-            &RecordComponent::loadChunk<TYPE>));
-    {
-        FORALL_SCALAR_OPENPMD_TYPES(USE_TYPE)
-    }
-#undef USE_TYPE
+    forallScalarJuliaTypes<UseType>(type);
 }

--- a/src/binding/julia/RecordComponent_load_chunk.cpp
+++ b/src/binding/julia/RecordComponent_load_chunk.cpp
@@ -11,8 +11,7 @@ struct UseType
     {
         type.method(
             "cxx_load_" + datatypeToString(determineDatatype<T>()),
-            static_cast<void (RecordComponent::*)(
-                std::shared_ptr<T>, Offset, Extent)>(
+            overload_cast<std::shared_ptr<T>, Offset, Extent>(
                 &RecordComponent::loadChunk<T>));
     }
 };

--- a/src/binding/julia/RecordComponent_make_constant.cpp
+++ b/src/binding/julia/RecordComponent_make_constant.cpp
@@ -2,14 +2,22 @@
 
 #include "defs.hpp"
 
+namespace
+{
+struct UseType
+{
+    template <typename T>
+    static void call(jlcxx::TypeWrapper<RecordComponent> &type)
+    {
+        type.method(
+            "cxx_make_constant_" + datatypeToString(determineDatatype<T>()),
+            &RecordComponent::makeConstant<T>);
+    }
+};
+} // namespace
+
 void define_julia_RecordComponent_make_constant(
     jlcxx::Module & /*mod*/, jlcxx::TypeWrapper<RecordComponent> &type)
 {
-#define USE_TYPE(NAME, ENUM, TYPE)                                             \
-    type.method(                                                               \
-        "cxx_make_constant_" NAME, &RecordComponent::makeConstant<TYPE>);
-    {
-        FORALL_SCALAR_OPENPMD_TYPES(USE_TYPE)
-    }
-#undef USE_TYPE
+    forallScalarJuliaTypes<UseType>(type);
 }

--- a/src/binding/julia/RecordComponent_store_chunk.cpp
+++ b/src/binding/julia/RecordComponent_store_chunk.cpp
@@ -11,8 +11,7 @@ struct UseType
     {
         type.method(
             "cxx_store_chunk_" + datatypeToString(determineDatatype<T>()),
-            static_cast<void (RecordComponent::*)(
-                std::shared_ptr<T>, Offset, Extent)>(
+            overload_cast<std::shared_ptr<T>, Offset, Extent>(
                 &RecordComponent::storeChunk<T>));
     }
 };

--- a/src/binding/julia/RecordComponent_store_chunk.cpp
+++ b/src/binding/julia/RecordComponent_store_chunk.cpp
@@ -2,17 +2,24 @@
 
 #include "defs.hpp"
 
+namespace
+{
+struct UseType
+{
+    template <typename T>
+    static void call(jlcxx::TypeWrapper<RecordComponent> &type)
+    {
+        type.method(
+            "cxx_store_chunk_" + datatypeToString(determineDatatype<T>()),
+            static_cast<void (RecordComponent::*)(
+                std::shared_ptr<T>, Offset, Extent)>(
+                &RecordComponent::storeChunk<T>));
+    }
+};
+} // namespace
+
 void define_julia_RecordComponent_store_chunk(
     jlcxx::Module & /*mod*/, jlcxx::TypeWrapper<RecordComponent> &type)
 {
-#define USE_TYPE(NAME, ENUM, TYPE)                                             \
-    type.method(                                                               \
-        "cxx_store_chunk_" NAME,                                               \
-        static_cast<void (RecordComponent::*)(                                 \
-            std::shared_ptr<TYPE>, Offset, Extent)>(                           \
-            &RecordComponent::storeChunk<TYPE>));
-    {
-        FORALL_SCALAR_OPENPMD_TYPES(USE_TYPE)
-    }
-#undef USE_TYPE
+    forallScalarJuliaTypes<UseType>(type);
 }

--- a/src/binding/julia/Series.cpp
+++ b/src/binding/julia/Series.cpp
@@ -78,8 +78,7 @@ void define_julia_Series(jlcxx::Module &mod)
     type.method("cxx_software", &Series::software);
     type.method(
         "cxx_set_software!",
-        static_cast<Series &(Series::*)(const std::string &,
-                                        const std::string &)>(
+        overload_cast<const std::string &, const std::string &>(
             &Series::setSoftware));
     type.method(
         "cxx_set_software!",

--- a/src/binding/julia/Series.cpp
+++ b/src/binding/julia/Series.cpp
@@ -21,7 +21,7 @@ namespace jlcxx
 template <>
 struct SuperType<Series>
 {
-    typedef Attributable type;
+    using type = Attributable;
 };
 } // namespace jlcxx
 
@@ -42,7 +42,7 @@ void define_julia_Series(jlcxx::Module &mod)
            sized_uint_t<sizeof(MPI_Comm)> ucomm,
            const std::string &options) {
             MPI_Comm comm;
-            static_assert(sizeof ucomm == sizeof comm, "");
+            static_assert(sizeof ucomm == sizeof comm);
             memcpy(&comm, &ucomm, sizeof comm);
             return Series(filepath, at, comm, options);
         });
@@ -52,7 +52,7 @@ void define_julia_Series(jlcxx::Module &mod)
            Access at,
            sized_uint_t<sizeof(MPI_Comm)> ucomm) {
             MPI_Comm comm;
-            static_assert(sizeof ucomm == sizeof comm, "");
+            static_assert(sizeof ucomm == sizeof comm);
             memcpy(&comm, &ucomm, sizeof comm);
             return Series(filepath, at, comm);
         });

--- a/src/binding/julia/WriteIterations.cpp
+++ b/src/binding/julia/WriteIterations.cpp
@@ -6,8 +6,7 @@
 
 void define_julia_WriteIterations(jlcxx::Module &mod)
 {
-    using iterations_t = Container<Iteration, uint64_t>;
-    using key_type = typename iterations_t::key_type;
+    using key_type = Series::IterationIndex_t;
     // using mapped_type = typename iterations_t::mapped_type;
 
     auto type = mod.add_type<WriteIterations>("WriteIterations");

--- a/src/binding/julia/shared_ptr.cpp
+++ b/src/binding/julia/shared_ptr.cpp
@@ -1,15 +1,25 @@
 // shared_ptr
 
 #include "defs.hpp"
+#include "openPMD/Datatype.hpp"
+#include <jlcxx/module.hpp>
+
+namespace
+{
+struct UseType
+{
+    template <typename T>
+    static void call(jlcxx::Module &mod)
+    {
+        mod.method(
+            "create_aliasing_shared_ptr_" +
+                datatypeToString(determineDatatype<T>()),
+            &create_aliasing_shared_ptr<T>);
+    }
+};
+} // namespace
 
 void define_julia_shared_ptr(jlcxx::Module &mod)
 {
-#define USE_TYPE(NAME, ENUM, TYPE)                                             \
-    mod.method(                                                                \
-        "create_aliasing_shared_ptr_" NAME,                                    \
-        &create_aliasing_shared_ptr<TYPE>);
-    {
-        FORALL_SCALAR_OPENPMD_TYPES(USE_TYPE)
-    }
-#undef USE_TYPE
+    forallScalarJuliaTypes<UseType>(mod);
 }


### PR DESCRIPTION
See https://github.com/openPMD/openPMD-api/pull/1025 for the base PR.

These are mainly code-style changes for now. 

The first commit replaces the `FORALL_OPENPMD_TYPES`-style macros with templates.
The main motivation for that is usually better usability together with debuggers. Since this is code that generates the Julia bindings and is not executed at runtime, this is not so critical and we can also skip them.

The second commit replaces `typedef` with `using`. Note that according to the [CPP reference]() "there is no difference between a type alias declaration and [typedef](https://en.cppreference.com/w/cpp/language/typedef) declaration". So, even though the base classes in the Julia bindings use `typedef`, there is no harm in using `using` here.

The third commit copies `overload_cast` from Pybind11 and applies it in order to avoid hard-to-read `static_cast` of overloaded function pointers. For some reason, Clang did not accept this trick in all instances, so there are a few places where the `static_cast` will have to stay.
(Are there any licensing issues here?)

Pinging for visibility @eschnett 